### PR TITLE
Update isort version for pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: "master" # Use the revision sha / tag you want to point at
+    rev: "main" # Use the revision sha / tag you want to point at
     hooks:
       - id: isort


### PR DESCRIPTION
The repo switched from "master" to "main" branch naming.